### PR TITLE
feat: change in quarter hours on dragging events (#68)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: Build
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   release:

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -1,5 +1,9 @@
 name: End-to-end tests
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   chrome:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,5 +1,9 @@
 name: Unit tests
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   test_london:

--- a/cypress/e2e/03-drag-and-drop.cy.ts
+++ b/cypress/e2e/03-drag-and-drop.cy.ts
@@ -50,7 +50,7 @@ describe('DragAndDrop.vue', () => {
 
       cy.get(EVENT_SELECTOR).click()
       cy.get('.event-flyout__row.is-time').then($el => {
-        expect($el).to.have.text('June 10, 2022 ⋅ 11:00 PM - 12:20 AM')
+        expect($el).to.have.text('June 10, 2022 ⋅ 11:45 PM - 1:05 AM')
       })
     })
   });

--- a/development/QalendarView.vue
+++ b/development/QalendarView.vue
@@ -147,7 +147,7 @@ export default defineComponent({
     reactToEvent(payload: any) {
       console.log(payload);
     },
-    
+
     updatedPeriod(e) {
       console.log('updated period')
       console.log(e)

--- a/docs/index.md
+++ b/docs/index.md
@@ -326,7 +326,7 @@ This allows you to even mix usage of custom events, and Qalendar-native events.
 
 ### Custom event dialog
 
-The dialog which is opened when an event is clicked can also be customized. To enable this, you first need set the configuration option `eventDialog.isCustom` to true, and then add a scoped slot, as in the example below. Please note, that the `v-if` is crucial in order to prevent errors. Until your user clicks an event, `props.eventDialogData` will be `null`.
+The dialog which is opened when an event is clicked can also be customized. To enable this, you first need to set the configuration option `eventDialog.isCustom` to true, and then add a scoped slot, as in the example below. Please note, that the `v-if` is crucial in order to prevent errors. Until your user clicks an event, `props.eventDialogData` will be `null`.
 
 For programmatically closing your custom dialog, you can trigger `props.closeEventDialog` as shown in the example below.
 

--- a/src/components/week/DayEvent.vue
+++ b/src/components/week/DayEvent.vue
@@ -194,7 +194,7 @@ export default defineComponent({
       canDrag: false, // set to true on mousedown and false on mouseup
       clientYDragStart: null as null | number,
       clientXDragStart: null as null | number,
-      changeInHoursOnDrag: 0,
+      changeInQuartersOnDrag: 0,
       changeInDaysOnDrag: 0,
       timeStartDragStart: this.eventProp.time.start,
       timeEndDragStart: this.eventProp.time.end,
@@ -351,7 +351,7 @@ export default defineComponent({
         this.event.time.end = newEndOfTimeDateTimeString;
     },
 
-    changeInHoursOnDrag(newValue) {
+    changeInQuartersOnDrag(newValue) {
       const eventCanBeDraggedFurther = DragAndDrop.eventCanBeDraggedFurther(
         this.event,
         newValue <= -1 ? 'backwards' : 'forwards'
@@ -359,11 +359,11 @@ export default defineComponent({
       if (!eventCanBeDraggedFurther) return;
 
       const newStart = this.time.addMinutesToDateTimeString(
-        newValue * 60,
+        newValue * 15,
         this.timeStartDragStart
       );
       const newEnd = this.time.addMinutesToDateTimeString(
-        newValue * 60,
+        newValue * 15,
         this.timeEndDragStart
       );
       // Only change the portion of a string that affects time
@@ -584,7 +584,7 @@ export default defineComponent({
       const dayChanged =
         this.changeInDaysOnDrag <= -1 || this.changeInDaysOnDrag > 0;
       const timeChanged =
-        this.changeInHoursOnDrag <= -1 || this.changeInHoursOnDrag > 0;
+        this.changeInQuartersOnDrag <= -1 || this.changeInQuartersOnDrag > 0;
 
       if (dayChanged || timeChanged)
         this.$emit('event-was-dragged', this.event);
@@ -612,10 +612,10 @@ export default defineComponent({
       const changeInTimePoints =
         (this.timePointsInDay / 100) * percentageOfDayChanged;
       const changeInMinutes = this.getMinutesFromTimePoints(changeInTimePoints);
-      this.changeInHoursOnDrag =
+      this.changeInQuartersOnDrag =
         changeInMinutes < 0
-          ? Math.ceil(changeInMinutes / 60)
-          : Math.floor(changeInMinutes / 60);
+          ? Math.ceil(changeInMinutes / 15)
+          : Math.floor(changeInMinutes / 15);
     },
 
     /**

--- a/src/helpers/DragAndDrop.ts
+++ b/src/helpers/DragAndDrop.ts
@@ -14,12 +14,17 @@ export default class DragAndDrop {
   static eventCanBeDraggedFurther(event: eventInterface, direction: 'backwards' | 'forwards') {
     if (direction === 'forwards') {
       const { hour: endHour } = time.getAllVariablesFromDateTimeString(event.time.end)
+      const { minutes: endMinutes } = time.getAllVariablesFromDateTimeString(event.time.end)
+      const { hour: startHour } = time.getAllVariablesFromDateTimeString(event.time.start)
+      const { minutes: startMinutes } = time.getAllVariablesFromDateTimeString(event.time.start)
 
-      return endHour < 23
+      return (endHour < 23 || (endHour === 23 && endMinutes < 45))
+       && (startHour < 23 || startHour === 23 && startMinutes < 45)
     }
 
     const { hour: startHour } = time.getAllVariablesFromDateTimeString(event.time.start)
+    const { minutes: startMinutes } = time.getAllVariablesFromDateTimeString(event.time.start)
 
-    return startHour > 0
+    return startHour > 0 || (startHour === 0 && startMinutes >= 15)
   }
 }


### PR DESCRIPTION
* feat: allow quarters in dragging

* feat: optimize drag behavior for quarter hours

* chore: add automated test and build for pushes on master

* chore: edit workflows

* chore: edit workflows

## Checklist

Please put "X" in the below checkboxes that apply::

- [ ] If committing a bugfix, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [ ] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [ ] If committing a new feature, I have also written an appropriate test suite for it. 

I have tested the following:  

- [ ] Qalendar component in month mode. 
- [ ] Qalendar component in week mode. 
- [ ] Qalendar component in day mode. 
- [ ] All of the above modes on emulated mobile view. 
- [ ] Dragging and dropping events. 
- [ ] Resizing events in day/week modes. 
- [ ] Clicking events to open event dialog. 

## This PR solves the following problem**. 

insert your description. 

## How to test this PR**. 

For example:  
1. Feed X and Y in the events-Prop. 
1. Click Z or A. 
2. Confirm that B is displayed. 
