### PR TITLE
feat: pt-BR language

### DIFF
--- a/development/components/DevToolbar.vue
+++ b/development/components/DevToolbar.vue
@@ -16,6 +16,7 @@
         <option value="ja-JP">ja-JP</option>
         <option value="ru-RU">ru-RU</option>
         <option value="zh-CN">zh-CN</option>
+        <option value="pt-BR">pt-BR</option>
       </select>
 
       <select id="nDays" v-model="nDays" name="nDays">

--- a/src/language/index.ts
+++ b/src/language/index.ts
@@ -14,6 +14,7 @@ export default {
       if (locale.startsWith("it")) locale = "it-IT";
       if (locale.startsWith("sv")) locale = "sv-SE";
       if (locale.startsWith("zh")) locale = "zh-CN";
+      if (locale.includes("BR")) locale = "pt-BR";
 
       return languageKeys[locale]
         ? languageKeys[locale]

--- a/src/language/index.ts
+++ b/src/language/index.ts
@@ -1,4 +1,4 @@
-import { languageKeys } from "./keys";
+import { languageKeys } from './keys';
 
 export default {
   data() {
@@ -9,16 +9,16 @@ export default {
 
   methods: {
     getLanguage(languageKeys: any, locale: string) {
-      if (locale.startsWith("de")) locale = "de-DE";
-      if (locale.startsWith("en")) locale = "en-US";
-      if (locale.startsWith("it")) locale = "it-IT";
-      if (locale.startsWith("sv")) locale = "sv-SE";
-      if (locale.startsWith("zh")) locale = "zh-CN";
-      if (locale.includes("BR")) locale = "pt-BR";
+      if (locale.startsWith('de')) locale = 'de-DE';
+      if (locale.startsWith('en')) locale = 'en-US';
+      if (locale.startsWith('it')) locale = 'it-IT';
+      if (locale.startsWith('sv')) locale = 'sv-SE';
+      if (locale.startsWith('zh')) locale = 'zh-CN';
+      if (locale.startsWith('pt')) locale = 'pt-BR';
 
       return languageKeys[locale]
         ? languageKeys[locale]
-        : languageKeys["en-US"] || "";
+        : languageKeys['en-US'] || '';
     },
   },
 };

--- a/src/language/keys.ts
+++ b/src/language/keys.ts
@@ -6,6 +6,7 @@ export const languageKeys = {
     "de-DE": "Woche",
     "sv-SE": "Vecka",
     "zh-CN": "周",
+    "pt-BR": "Semana",
   },
   month: {
     "it-IT": "Mese",
@@ -13,6 +14,7 @@ export const languageKeys = {
     "de-DE": "Monat",
     "sv-SE": "Månad",
     "zh-CN": "月",
+    "pt-BR": "Mês",
   },
   day: {
     "it-IT": "Giorno",
@@ -20,6 +22,7 @@ export const languageKeys = {
     "de-DE": "Tag",
     "sv-SE": "Dag",
     "zh-CN": "日",
+    "pt-BR": "Dia",
   },
 
   /** Other keys */
@@ -29,5 +32,6 @@ export const languageKeys = {
     "de-DE": "+ weitere Ereignisse",
     "sv-SE": "+ fler händelser",
     "zh-CN": "列出其他结果",
+    "pt-BR": "+ mais eventos",
   },
 };


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply::

- [ ] If committing a bugfix, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [X] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [ ] If committing a new feature, I have also written an appropriate test suite for it. 

I have tested the following:  

- [X] Qalendar component in month mode. 
- [X] Qalendar component in week mode. 
- [X] Qalendar component in day mode. 
- [X] All of the above modes on emulated mobile view. 
- [X] Dragging and dropping events. 
- [X] Resizing events in day/week modes. 
- [X] Clicking events to open event dialog. 

## This PR solves the following problem**. 

1- Run project:

`yarn dev`

2- Choose 'pt-BR' language in DevToolbar;

3- The button to change the calendar view will be in brazilian portuguese:

![image](https://user-images.githubusercontent.com/28320844/197027671-8199c5e0-94d0-4975-8293-d224a52264db.png)

