### PR TITLE
fix: improve event flyout position on small screens

### DIFF
--- a/cypress/e2e/02-five-day-week.cy.ts
+++ b/cypress/e2e/02-five-day-week.cy.ts
@@ -34,7 +34,7 @@ describe('FiveDayWeek.vue', () => {
     cy.get('.event-flyout').should('be.visible')
 
     // 3. Click somewhere outside the event flyout, and assert that it is now not visible anymore
-    cy.get('.calendar-header').click()
+    cy.get('.calendar-header__mode-picker').click()
     cy.get('.event-flyout').should('not.be.visible')
   })
 })

--- a/src/components/partials/EventFlyout.vue
+++ b/src/components/partials/EventFlyout.vue
@@ -190,12 +190,12 @@ export default defineComponent({
     },
 
     eventFlyoutInlineStyles() {
-      if ([typeof this.top, typeof this.left].some((x) => x !== 'number')) {
+      if (typeof this.top === 'number' && !this.left) {
         return {
-          top: '50%',
+          top: this.top + 'px',
           left: '50%',
-          position: 'absolute' as const, // casting, since tsc otherwise thinks we're casting 'string' to 'PositionProperty'
-          transform: 'translate(-50%, -50%)',
+          position: 'fixed' as const,
+          transform: 'translateX(-50%)',
         };
       }
 
@@ -235,7 +235,7 @@ export default defineComponent({
         setTimeout(() => {
           this.calendarEvent = value;
           this.isVisible = !!value;
-          this.setFlyoutPosition();
+          this.$nextTick(() => this.setFlyoutPosition());
         }, 10);
       },
     },
@@ -265,8 +265,8 @@ export default defineComponent({
         calendar ? calendar.getBoundingClientRect() : null
       );
 
-      this.top = flyoutPosition?.top || null;
-      this.left = flyoutPosition?.left || null;
+      this.top = typeof flyoutPosition?.top === 'number' ? flyoutPosition.top : null;
+      this.left = typeof flyoutPosition?.left === 'number' ? flyoutPosition.left : null;
     },
 
     editEvent() {

--- a/src/helpers/EventFlyoutPosition.ts
+++ b/src/helpers/EventFlyoutPosition.ts
@@ -90,7 +90,14 @@ export default class EventFlyoutPosition {
       };
     }
 
-    // Fallback - will lead to the flyout being centered horizontally and vertically over the calendar
-    return { top: null, left: null };
+    // Fallback for smaller screens - scenario 1
+    // Flyout is glued to the bottom of the calendar and horizontally centered
+    if (spaceBottom < flyoutDimensions.height) {
+      return { top: calendarDomRect.bottom - flyoutDimensions.height, left: null };
+    }
+
+    // Fallback for smaller screens - scenario 2
+    // Flyout is placed vertically based on the top of the event, and centered horizontally
+    return { top: eventElementDOMRect.top, left: null };
   }
 }

--- a/tests/unit/helpers/EventFlyoutPosition.test.ts
+++ b/tests/unit/helpers/EventFlyoutPosition.test.ts
@@ -248,7 +248,7 @@ describe("EventFlyoutPositionHelper.ts", () => {
     expect(position.left).toBe(641);
   });
 
-  test("Getting null values for small calendar widths, which are then used to position flyout centered over the calendar", () => {
+  test("Getting dimensions for flyout on small screens, where there is enough space to the bottom to place flyout based on the top of event", () => {
     const eventDOMRect = {
       x: 66,
       y: 495,
@@ -279,7 +279,42 @@ describe("EventFlyoutPositionHelper.ts", () => {
 
     if (!position) throw new Error("No position");
 
-    expect(position.top).toBeNull();
+    expect(position.top).toBe(495);
+    expect(position.left).toBeNull();
+  });
+
+  test("Getting dimensions for flyout on small screens, where there is not enough space to the bottom to place flyout based on the top of event", () => {
+    const eventDOMRect = {
+      x: 66,
+      y: 495,
+      width: 509,
+      height: 75,
+      top: 495,
+      right: 575,
+      bottom: 570,
+      left: 66,
+    };
+    const flyoutDimensions = { height: 300, width: 400 };
+    const calendarDomRect = {
+      x: 8,
+      y: 26,
+      width: 568,
+      height: 702,
+      top: 26,
+      right: 576,
+      bottom: 728,
+      left: 8,
+    };
+
+    const position = eventFlyoutPosition.calculateFlyoutPosition(
+      eventDOMRect,
+      flyoutDimensions,
+      calendarDomRect
+    );
+
+    if (!position) throw new Error("No position");
+
+    expect(position.top).toBe(calendarDomRect.bottom - flyoutDimensions.height);
     expect(position.left).toBeNull();
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,6 @@
     "types": ["vite/client", "cypress"],
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue", "cypress/**/*.ts"],
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue", "cypress/**/*.cy.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply::

- [X] If committing a bugfix, I have tested it in different browsers (Chrome, Firefox, Safari). 

I have tested the following:  

- [X] Qalendar component in month mode. 
- [X] Qalendar component in week mode. 
- [X] Qalendar component in day mode. 
- [X] All of the above modes on emulated mobile view. 
- [X] Dragging and dropping events. 
- [X] Resizing events in day/week modes. 
- [X] Clicking events to open event dialog. 

## This PR solves the following problem**. 

Fixes bad positioning of the event flyout on small screens
