### PR TITLE
Translate Dropdpown menu to Frensh

### DIFF
--- a/development/components/DevToolbar.vue
+++ b/development/components/DevToolbar.vue
@@ -17,7 +17,6 @@
         <option value="ru-RU">ru-RU</option>
         <option value="zh-CN">zh-CN</option>
         <option value="pt-BR">pt-BR</option>
-        <option value="fr-FR">fr-FR</option>
       </select>
 
       <select id="nDays" v-model="nDays" name="nDays">

--- a/development/components/DevToolbar.vue
+++ b/development/components/DevToolbar.vue
@@ -17,6 +17,7 @@
         <option value="ru-RU">ru-RU</option>
         <option value="zh-CN">zh-CN</option>
         <option value="pt-BR">pt-BR</option>
+        <option value="fr-FR">fr-FR</option>
       </select>
 
       <select id="nDays" v-model="nDays" name="nDays">

--- a/src/language/index.ts
+++ b/src/language/index.ts
@@ -15,6 +15,7 @@ export default {
       if (locale.startsWith('sv')) locale = 'sv-SE';
       if (locale.startsWith('zh')) locale = 'zh-CN';
       if (locale.startsWith('pt')) locale = 'pt-BR';
+      if (locale.startsWith('fr')) locale = 'fr-FR';
 
       return languageKeys[locale]
         ? languageKeys[locale]

--- a/src/language/index.ts
+++ b/src/language/index.ts
@@ -15,7 +15,6 @@ export default {
       if (locale.startsWith('sv')) locale = 'sv-SE';
       if (locale.startsWith('zh')) locale = 'zh-CN';
       if (locale.startsWith('pt')) locale = 'pt-BR';
-      if (locale.startsWith('fr')) locale = 'fr-FR';
 
       return languageKeys[locale]
         ? languageKeys[locale]

--- a/src/language/keys.ts
+++ b/src/language/keys.ts
@@ -7,6 +7,7 @@ export const languageKeys = {
     "sv-SE": "Vecka",
     "zh-CN": "周",
     "pt-BR": "Semana",
+    "fr-FR": "Semaine"
   },
   month: {
     "it-IT": "Mese",
@@ -15,6 +16,7 @@ export const languageKeys = {
     "sv-SE": "Månad",
     "zh-CN": "月",
     "pt-BR": "Mês",
+    "fr-FR": "Mois",
   },
   day: {
     "it-IT": "Giorno",
@@ -23,6 +25,7 @@ export const languageKeys = {
     "sv-SE": "Dag",
     "zh-CN": "日",
     "pt-BR": "Dia",
+    "fr-FR": "Jour",
   },
 
   /** Other keys */
@@ -33,5 +36,6 @@ export const languageKeys = {
     "sv-SE": "+ fler händelser",
     "zh-CN": "列出其他结果",
     "pt-BR": "+ mais eventos",
+    "fr-FR": "+ plus d'événements",
   },
 };

--- a/src/language/keys.ts
+++ b/src/language/keys.ts
@@ -36,5 +36,6 @@ export const languageKeys = {
     "sv-SE": "+ fler händelser",
     "zh-CN": "列出其他结果",
     "pt-BR": "+ mais eventos",
+    "fr-FR": "+ d'autres événements",
   },
 };

--- a/src/language/keys.ts
+++ b/src/language/keys.ts
@@ -7,6 +7,7 @@ export const languageKeys = {
     "sv-SE": "Vecka",
     "zh-CN": "周",
     "pt-BR": "Semana",
+    "fr-FR": "Semaine",
   },
   month: {
     "it-IT": "Mese",
@@ -15,6 +16,7 @@ export const languageKeys = {
     "sv-SE": "Månad",
     "zh-CN": "月",
     "pt-BR": "Mês",
+    "fr-FR": "Mois",
   },
   day: {
     "it-IT": "Giorno",
@@ -23,6 +25,7 @@ export const languageKeys = {
     "sv-SE": "Dag",
     "zh-CN": "日",
     "pt-BR": "Dia",
+    "fr-FR": "Jour",
   },
 
   /** Other keys */

--- a/src/language/keys.ts
+++ b/src/language/keys.ts
@@ -7,7 +7,6 @@ export const languageKeys = {
     "sv-SE": "Vecka",
     "zh-CN": "周",
     "pt-BR": "Semana",
-    "fr-FR": "Semaine"
   },
   month: {
     "it-IT": "Mese",
@@ -16,7 +15,6 @@ export const languageKeys = {
     "sv-SE": "Månad",
     "zh-CN": "月",
     "pt-BR": "Mês",
-    "fr-FR": "Mois",
   },
   day: {
     "it-IT": "Giorno",
@@ -25,7 +23,6 @@ export const languageKeys = {
     "sv-SE": "Dag",
     "zh-CN": "日",
     "pt-BR": "Dia",
-    "fr-FR": "Jour",
   },
 
   /** Other keys */
@@ -36,6 +33,5 @@ export const languageKeys = {
     "sv-SE": "+ fler händelser",
     "zh-CN": "列出其他结果",
     "pt-BR": "+ mais eventos",
-    "fr-FR": "+ plus d'événements",
   },
 };


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply::

- [ ] If committing a bugfix, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [x] If committing a new feature, I have also written an appropriate test suite for it. 

I have tested the following:  

- [X] Qalendar component in month mode. 
- [X] Qalendar component in week mode. 
- [X] Qalendar component in day mode. 
- [X] All of the above modes on emulated mobile view. 
- [ ] Dragging and dropping events. 
- [ ] Resizing events in day/week modes. 
- [ ] Clicking events to open event dialog. 

## This PR solves the following problem**. 

Translate dropdown menu to frensh.

## How to test this PR**. 

1. `npm run dev`
2. change language in DevToolbar to "fr-FR"
3. dropdown of representation mode change like this 
![fr-FR](https://user-images.githubusercontent.com/118192690/201861556-cf17309b-7a4f-4a9a-84cb-a25765aa263b.JPG)


**Notes**

- I didn't test effects on events because changes are not specific to events.
- I'm not familiar with git that's why I revert the first commit, I thought that I did a mistake. But it's all good in the last commit.

