### PR TITLE
fix: missing type check on config.week.scrollToHour

### DIFF
--- a/src/components/week/Week.vue
+++ b/src/components/week/Week.vue
@@ -372,15 +372,15 @@ export default defineComponent({
     scrollOnMount() {
       const weekWrapper = document.querySelector('.calendar-week__wrapper');
 
-      if (weekWrapper) {
-        this.$nextTick(() => {
-          const weekHeight = +this.weekHeight.split('p')[0];
-          const oneHourInPixel = weekHeight / 24;
-          const hourToScrollTo = this.config.week?.scrollToHour || 8;
-          const desiredNumberOfPixelsToScroll = oneHourInPixel * hourToScrollTo;
-          weekWrapper.scroll(0, desiredNumberOfPixelsToScroll - 10); // -10 to display the hour in DayTimeline
-        })
-      }
+      if (!weekWrapper) return;
+
+      this.$nextTick(() => {
+        const weekHeight = +this.weekHeight.split('p')[0];
+        const oneHourInPixel = weekHeight / 24;
+        const hourToScrollTo = typeof this.config.week?.scrollToHour === 'number' ? this.config.week.scrollToHour : 8;
+        const desiredNumberOfPixelsToScroll = oneHourInPixel * hourToScrollTo;
+        weekWrapper.scroll(0, desiredNumberOfPixelsToScroll - 10); // -10 to display the hour in DayTimeline
+      })
     },
 
     setDayIntervals() {


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply::

- [ ] If committing a bugfix, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [ ] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [ ] If committing a new feature, I have also written an appropriate test suite for it. 

I have tested the following:  

- [ ] Qalendar component in month mode. 
- [ ] Qalendar component in week mode. 
- [ ] Qalendar component in day mode. 
- [ ] All of the above modes on emulated mobile view. 
- [ ] Dragging and dropping events. 
- [ ] Resizing events in day/week modes. 
- [ ] Clicking events to open event dialog. 

## This PR solves the following problem**. 

insert your description. 

## How to test this PR**. 

For example:  
1. Feed X and Y in the events-Prop. 
1. Click Z or A. 
2. Confirm that B is displayed. 
