### PR TITLE
fix: prevent qalendar from resetting to default mode when being resized

### DIFF
--- a/cypress/e2e/01-smoke.cy.ts
+++ b/cypress/e2e/01-smoke.cy.ts
@@ -51,4 +51,22 @@ describe('Rendering the component', () => {
       expect(periodNameElement.text()).to.not.equal(periodName)
     })
   });
+
+  it('Keeps selected mode on resizing', () => {
+    // Start in week mode
+    cy.get('.mode-is-week')
+
+    // Change to another mode
+    cy
+      // @ts-ignore
+      .changeMode('month')
+
+    cy.get('.mode-is-month')
+
+    // Resize the window
+    cy.viewport(1000, 500).wait(1000)
+
+    // Expect to still be in the same mode
+    cy.get('.mode-is-month')
+  })
 })

--- a/src/Qalendar.vue
+++ b/src/Qalendar.vue
@@ -268,9 +268,7 @@ export default defineComponent({
 
       this.calendarWidth = calendarRoot.clientWidth;
 
-      if (this.calendarWidth < dayModeBreakpoint) this.mode = 'day';
-      if (this.calendarWidth >= dayModeBreakpoint)
-        this.mode = this.config?.defaultMode || 'week';
+      if (this.calendarWidth < dayModeBreakpoint && this.mode !== 'day') this.mode = 'day';
     },
 
     setPeriodOnMount() {


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply::

- [ ] If committing a bugfix, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [ ] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [ ] If committing a new feature, I have also written an appropriate test suite for it. 

I have tested the following:  

- [ ] Qalendar component in month mode. 
- [ ] Qalendar component in week mode. 
- [ ] Qalendar component in day mode. 
- [ ] All of the above modes on emulated mobile view. 
- [ ] Dragging and dropping events. 
- [ ] Resizing events in day/week modes. 
- [ ] Clicking events to open event dialog. 

## This PR solves the following problem**. 

insert your description. 

## How to test this PR**. 

For example:  
1. Feed X and Y in the events-Prop. 
1. Click Z or A. 
2. Confirm that B is displayed. 
