### PR TITLE
feat: add config option to switch modes with horizontal menu

### DIFF
--- a/development/QalendarView.vue
+++ b/development/QalendarView.vue
@@ -153,7 +153,7 @@ export default defineComponent({
         month: {
           showTrailingAndLeadingDates: false,
         },
-        showModesAsHorizontalMenu: false,
+        showModesAsHorizontalMenu: true,
       } as configInterface,
       events: [] as eventInterface[],
 

--- a/development/QalendarView.vue
+++ b/development/QalendarView.vue
@@ -152,7 +152,8 @@ export default defineComponent({
         },
         month: {
           showTrailingAndLeadingDates: false,
-        }
+        },
+        showModesAsHorizontalMenu: false,
       } as configInterface,
       events: [] as eventInterface[],
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -511,6 +511,10 @@ Some features of the calendar can be disabled/hidden through configuration.
 | `eventDialog.isDisabled`  |                        boolean                        | Prevent the event dialog from showing at all |
 |  `eventDialog.isCustom`   |                        boolean                        |   Enable customization of the event dialog   |
 
+## Fixed mode menu
+
+If you prefer to view the modes menu options at all times, enabling you to choose day, week or month with a single click, set the `showModesAsHorizontalMenu` to true in the config file.
+
 ## Date picker
 
 ### Usage

--- a/src/components/header/Header.vue
+++ b/src/components/header/Header.vue
@@ -36,14 +36,17 @@
         class="calendar-header__mode-picker"
       >
         <template
-          v-for="mode in modeOptions"
-          :key="mode"
+          v-for="mode_ in modeOptions"
+          :key="mode_"
         >
           <div
             class="calendar-header__mode-value"
-            @click="$emit('change-mode', mode)"
+            @click="$emit('change-mode', mode_)"
+            :class="{
+              'calendar-header__mode-active': mode_ === mode,
+            }"
           >
-            {{ getLanguage(languageKeys[mode], time.CALENDAR_LOCALE) }}
+            {{ getLanguage(languageKeys[mode_], time.CALENDAR_LOCALE) }}
           </div>
         </template>
       </div>
@@ -275,6 +278,10 @@ export default defineComponent({
         color: var(--qalendar-gray-quite-dark);
       }
     }
+  }
+
+  &__mode-active {
+      background-color:  var(--qalendar-light-gray);
   }
 
   &__mode-picker {

--- a/src/components/header/Header.vue
+++ b/src/components/header/Header.vue
@@ -30,39 +30,63 @@
         @updated="handlePeriodChange"
       />
 
+      <!-- mode menu as horizontal group -->
       <div
-        v-if="!onlyDayModeIsEnabled"
+        v-if="showModesAsHorizontalMenu"
         class="calendar-header__mode-picker"
       >
-        <div
-          class="calendar-header__mode-value"
-          @click="showModePicker = true"
+        <template
+          v-for="mode in modeOptions"
+          :key="mode"
         >
-          {{ modeName }}
-        </div>
-
-        <div
-          v-if="showModePicker"
-          class="calendar-header__mode-options"
-          @mouseleave="showModePicker = false"
-        >
-          <template
-            v-for="mode in modeOptions"
-            :key="mode"
+          <div
+            class="calendar-header__mode-value"
+            @click="$emit('change-mode', mode)"
           >
-            <div
-              v-if="
-                !config.disableModes || !config.disableModes.includes(mode)
-              "
-              class="calendar-header__mode-option"
-              :class="'is-' + mode + '-mode'"
-              @click="$emit('change-mode', mode)"
+            {{ getLanguage(languageKeys[mode], time.CALENDAR_LOCALE) }}
+          </div>
+        </template>
+      </div>
+
+      <!-- mode menu as dropdown menu -->
+      <div
+        v-else
+      >
+        <div
+          v-if="!onlyDayModeIsEnabled"
+          class="calendar-header__mode-picker"
+        >
+          <div
+            class="calendar-header__mode-value"
+            @click="showModePicker = true"
+          >
+            {{ modeName }}
+          </div>
+
+          <div
+            v-if="showModePicker"
+            class="calendar-header__mode-options"
+            @mouseleave="showModePicker = false"
+          >
+            <template
+              v-for="mode in modeOptions"
+              :key="mode"
             >
-              {{ getLanguage(languageKeys[mode], time.CALENDAR_LOCALE) }}
-            </div>
-          </template>
+              <div
+                v-if="
+                  !config.disableModes || !config.disableModes.includes(mode)
+                "
+                class="calendar-header__mode-option"
+                :class="'is-' + mode + '-mode'"
+                @click="$emit('change-mode', mode)"
+              >
+                {{ getLanguage(languageKeys[mode], time.CALENDAR_LOCALE) }}
+              </div>
+            </template>
+          </div>
         </div>
       </div>
+
     </div>
   </div>
 </template>
@@ -125,6 +149,7 @@ export default defineComponent({
       },
       currentPeriod: this.period,
       showModePicker: false,
+      showModesAsHorizontalMenu: this.config.showModesAsHorizontalMenu,
     };
   },
 
@@ -272,6 +297,10 @@ export default defineComponent({
       display: flex;
       align-items: center;
       user-select: none;
+    }
+
+    .calendar-header__mode-value:hover {
+      background-color: lightgrey;
     }
 
     .calendar-header__mode-options {

--- a/src/typings/config.interface.ts
+++ b/src/typings/config.interface.ts
@@ -59,6 +59,7 @@ export interface configInterface {
   };
   defaultMode?: modeType;
   disableModes?: ('week'|'month'|string)[];
+  showModesAsHorizontalMenu?: boolean;
   isSilent?: boolean;
   dayIntervals?: dayIntervalsType;
   eventDialog?: {


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply::

- [ ] If committing a bugfix, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [ ] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [ ] If committing a new feature, I have also written an appropriate test suite for it. 
- [x ] New feature, non-issued features, no test suite

I have tested the following:  

- [x ] Qalendar component in month mode. 
- [ x] Qalendar component in week mode. 
- [ x] Qalendar component in day mode. 
- [ ] All of the above modes on emulated mobile view. (Oh no, not working correctly!)
- [ ] Dragging and dropping events. 
- [ ] Resizing events in day/week modes. (resizing windows the week option disappears when width < 744px)
- [ ] Clicking events to open event dialog. 

## This PR solves the following problem**. 

I have to click twice and navigate the modes menu to switch day/week/month. With a new config property I can set the menu horizontally so that I only need to click once.

## How to test this PR**. 

For example:  
1. In development/CalendarView.vue, set "config.showModesAsHorizontalMenu: true" in data()
2. $ npm run dev
2. Confirm that the horizontal menu is displayed and functional
