### PR TITLE
Update WeekTimeline.vue

### DIFF
--- a/src/components/week/WeekTimeline.vue
+++ b/src/components/week/WeekTimeline.vue
@@ -11,7 +11,7 @@
       @click="$emit('day-was-clicked', time.dateStringFrom(day.dateTimeString))"
     >
       <div class="week-timeline__day-name">
-        {{ day.dayName.substring(0, 2).toUpperCase() }}
+        {{ getWeekTimeStr(day) }}
       </div>
 
       <div class="week-timeline__date">
@@ -89,6 +89,10 @@ export default defineComponent({
 
       return date;
     },
+    getWeekTimeStr(day: dayInterface) {
+      const isCN = this.config?.locale?.toLowerCase() === 'zh-cn';
+      return isCN ? day.dayName : day.dayName.substring(0, 2).toUpperCase();
+    }
   },
 });
 </script>


### PR DESCRIPTION
fix: When { locale: ‘zh-CN’ }, the weekly mode is displayed abnormally

## Checklist

Please put "X" in the below checkboxes that apply::

- [ ] If committing a bugfix, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [ ] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [ ] If committing a new feature, I have also written an appropriate test suite for it. 

I have tested the following:  

- [ ] Qalendar component in month mode. 
- [ ] Qalendar component in week mode. 
- [ ] Qalendar component in day mode. 
- [ ] All of the above modes on emulated mobile view. 
- [ ] Dragging and dropping events. 
- [ ] Resizing events in day/week modes. 
- [ ] Clicking events to open event dialog. 

## This PR solves the following problem**. 

insert your description. 

## How to test this PR**. 

For example:  
1. Feed X and Y in the events-Prop. 
1. Click Z or A. 
2. Confirm that B is displayed. 
