### PR TITLE
feat: add config option to disable flyout closing when clicking outside

### DIFF
--- a/src/components/partials/EventFlyout.vue
+++ b/src/components/partials/EventFlyout.vue
@@ -334,8 +334,9 @@ export default defineComponent({
 
       const isClickOutside = !flyout.contains(e.target);
       const isClickOnEvent = !!e.target.closest('.is-event');
+      const closeOnClickOutside = this.config.eventDialog?.closeOnClickOutside ?? true;
 
-      if (this.isVisible && isClickOutside && !isClickOnEvent) {
+      if (this.isVisible && isClickOutside && !isClickOnEvent && closeOnClickOutside) {
         this.closeFlyout();
       }
     },

--- a/src/typings/config.interface.ts
+++ b/src/typings/config.interface.ts
@@ -66,6 +66,7 @@ export interface configInterface {
   eventDialog?: {
     isDisabled?: boolean;
     isCustom?: boolean;
+    closeOnClickOutside?: boolean;
   }
   dayBoundaries?: {
     start: number; // integer between 0 and 24

--- a/tests/unit/components/EventFlyout.test-utils.ts
+++ b/tests/unit/components/EventFlyout.test-utils.ts
@@ -4,6 +4,7 @@ import { EventColor } from "../../../src/typings/interfaces/event.interface";
 import { shallowMount } from "@vue/test-utils";
 import Time, { WEEK_START_DAY } from "../../../src/helpers/Time";
 import { expect, vi } from "vitest";
+import { configInterface } from "../../../src/typings/config.interface";
 
 export const eventWithTitle = (title: string) => {
   return new EventBuilder({
@@ -88,17 +89,24 @@ export const eventWithColorScheme = (colorScheme: string) => {
 }
 
 export const propsForAllTests = {
-  config: {},
+  config: {} satisfies configInterface as configInterface,
   time: new Time(WEEK_START_DAY.SUNDAY, 'en-US'),
 }
 
-export const whenIsVisible = () => {
-  const wrapper = shallowMount(EventFlyout,{
+export const whenIsVisible = (closeOnClickOutside = true) => {
+  const wrapper = shallowMount(EventFlyout, {
     props: {
       ...propsForAllTests,
-      calendarEventProp: eventWithTitle('Foo')
+      calendarEventProp: eventWithTitle('Foo'),
+      config: {
+        ...propsForAllTests.config,
+        eventDialog: {
+          ...propsForAllTests.config.eventDialog,
+          closeOnClickOutside,
+        },
+      },
     },
-    attachTo: document.body
+    attachTo: document.body,
   })
   const closeFlyoutSpy = vi.spyOn(wrapper.vm, 'closeFlyout')
   const eventFlyoutElement = document.createElement('div')

--- a/tests/unit/components/EventFlyout.test.ts
+++ b/tests/unit/components/EventFlyout.test.ts
@@ -296,4 +296,16 @@ describe('EventFlyout.vue', () => {
 
     expect(closeFlyoutSpy).toHaveBeenCalled()
   })
+
+  it("should not close flyout on clicking, when disabled through config",  () => {
+    const {
+      wrapper,
+      closeFlyoutSpy,
+      elementOutsideFlyout
+    } = whenIsVisible(false)
+
+    wrapper.vm.closeFlyoutOnClickOutside({ target: elementOutsideFlyout })
+
+    expect(closeFlyoutSpy).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply::

- [ ] If committing a bugfix, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [ ] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [X] If committing a new feature, I have also written an appropriate test suite for it. 

I have tested the following:  

- [X] Qalendar component in month mode. 
- [X] Qalendar component in week mode. 
- [X] Qalendar component in day mode. 
- [ ] All of the above modes on emulated mobile view. 
- [ ] Dragging and dropping events. 
- [ ] Resizing events in day/week modes. 
- [X] Clicking events to open event dialog. 

## This PR solves the following problem**. 

I'd like to be able to disable the automatic closing of the flyout when clicking outside of it.

The default of this configuration is `true`, to not have a breaking change, and it simply prevents the invocation of `this.closeFlyout()`. I'm not messing with the registration of the event handler, it is always going to be there, so if the `closeOnClickOutside` config is changed programmatically it is simply going to work.

I tested it manually because i haven't used cypress for years and because I was interested in validating the idea and my implementation of it.