### PR TITLE
feat: exposes gotoPeriod method to top level, removes unused event parameter

### DIFF
--- a/src/Qalendar.vue
+++ b/src/Qalendar.vue
@@ -18,6 +18,7 @@
       </Transition>
 
       <AppHeader
+        ref="appHeader"
         :key="wasInitialized + mode"
         :config="config"
         :mode="mode"
@@ -335,7 +336,11 @@ export default defineComponent({
     handleDateWasClicked(payload: string) {
       this.$emit('day-was-clicked', payload); // TODO: remove with v4. day-was-clicked is deprecated
       this.$emit('date-was-clicked', payload);
-    }
+    },
+
+    goToPeriod(direction: 'previous' | 'next') {
+      (this.$refs.appHeader as typeof AppHeader).goToPeriod(direction);
+    },
   },
 });
 </script>

--- a/src/components/header/Header.vue
+++ b/src/components/header/Header.vue
@@ -12,13 +12,13 @@
         <FontAwesomeIcon
           class="calendar-header__chevron-arrow calendar-header__chevron-arrow-left"
           :icon="icons.chevronLeft"
-          @click="goToPeriod($event, 'previous')"
+          @click="goToPeriod('previous')"
         />
 
         <FontAwesomeIcon
           class="calendar-header__chevron-arrow calendar-header__chevron-arrow-right"
           :icon="icons.chevronRight"
-          @click="goToPeriod($event, 'next')"
+          @click="goToPeriod('next')"
         />
       </div>
 
@@ -188,7 +188,7 @@ export default defineComponent({
       this.$emit('updated-period', value);
     },
 
-    goToPeriod(event: MouseEvent, direction: 'previous' | 'next') {
+    goToPeriod(direction: 'previous' | 'next') {
       (this.$refs.periodSelect as typeof DatePicker).goToPeriod(direction);
     },
   }

--- a/tests/unit/components/Qalendar.test.ts
+++ b/tests/unit/components/Qalendar.test.ts
@@ -481,7 +481,7 @@ describe('Qalendar.vue', () => {
     expect(wrapper.vm.mode).toBe('day')
   })
 
-  it('should go to invoke the goToPeriod in the header and go forward in time', () => {
+  it('should invoke the goToPeriod method in the header', () => {
     const wrapper = mount(Qalendar)
     const header = wrapper.findComponent({ name: 'AppHeader' })
     const goToPeriodSpy = vi.spyOn(header.vm, 'goToPeriod')

--- a/tests/unit/components/Qalendar.test.ts
+++ b/tests/unit/components/Qalendar.test.ts
@@ -480,4 +480,15 @@ describe('Qalendar.vue', () => {
     month.vm.$emit('updated-period', { start: new Date(), end: new Date(), selectedDate: new Date() })
     expect(wrapper.vm.mode).toBe('day')
   })
+
+  it('should go to invoke the goToPeriod in the header and go forward in time', () => {
+    const wrapper = mount(Qalendar)
+    const header = wrapper.findComponent({ name: 'AppHeader' })
+    const goToPeriodSpy = vi.spyOn(header.vm, 'goToPeriod')
+    const expectedDirection = 'forward'
+
+    wrapper.vm.goToPeriod(expectedDirection)
+
+    expect(goToPeriodSpy).toHaveBeenCalledWith(expectedDirection)
+  })
 })


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply::

- [ ] If committing a bugfix, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [x] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [ ] If committing a new feature, I have also written an appropriate test suite for it. 

I have tested the following:  

- [ ] Qalendar component in month mode. 
- [ ] Qalendar component in week mode. 
- [ ] Qalendar component in day mode. 
- [ ] All of the above modes on emulated mobile view. 
- [ ] Dragging and dropping events. 
- [ ] Resizing events in day/week modes. 
- [ ] Clicking events to open event dialog. 

## This PR solves the following problem**. 
Allows for more customization of the calendar. A fully custom header can be achieved by hiding the default one, calling for example `@click="$refs.calendar.mode = 'month'` to change mode, and with my pull request, utilize the existing goToPeriod method to change period rather than having to create a method that modifies selected-date.

I have run the existing Vitest suite, and I guess an improvement could be to create a test along with buttons in the same file as the Qalendar element, with the test running the method through the ref by clicking

## How to test this PR**. 

For example:  
1. Add a template ref to wherever Qalendar is used
2. Create new buttons, with a click event that fires `$refs.<refname>.goToPeriod('next')` and `$refs.<refname>.goToPeriod('previous')`
