### PR TITLE
fix: event bubbling wrong when clicking on month day event

### DIFF
--- a/src/components/month/Day.vue
+++ b/src/components/month/Day.vue
@@ -9,7 +9,7 @@
       'is-selected': isSelected,
       'is-today': isToday,
     }"
-    @click="emitDayWasClicked"
+    @click.self="emitDayWasClicked"
     @dragleave="handleDragLeave"
     @dragover="handleDragOver"
     @drop="handleDrop"

--- a/tests/unit/components/month/Day.test.ts
+++ b/tests/unit/components/month/Day.test.ts
@@ -82,6 +82,15 @@ describe("Day.vue", () => {
     expect(underTest.emitted("date-was-clicked")[0][0]).toBe("2022-05-23");
   });
 
+  it('should not emit "date-was-clicked" when an event is clicked', () => {
+    const underTest = day({ props: defaultProps });
+    const dayEvent = underTest.find(".calendar-month__event");
+
+    dayEvent.trigger("click");
+
+    expect(underTest.emitted("date-was-clicked")).toBeFalsy();
+  })
+
   it('should not emit custom event "day-was-selected" when qalendar !isSmall and a day is clicked', async () => {
     const underTest = day({ props: {
       ...defaultProps,


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply::

- [x] If committing a bugfix, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [ ] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [ ] If committing a new feature, I have also written an appropriate test suite for it. 

I have tested the following:  

- [x] Qalendar component in month mode. 
- [ ] Qalendar component in week mode. 
- [ ] Qalendar component in day mode. 
- [ ] All of the above modes on emulated mobile view. 
- [ ] Dragging and dropping events. 
- [ ] Resizing events in day/week modes. 
- [ ] Clicking events to open event dialog. 

## This PR solves the following problem**. 

Prevents the date-was-clicked event from bubbling up when an event is clicked.
I saw that the `.self` modifier was removed 6 months ago on that exact line, maybe there is some reason for this? Otherwise, I tested adding `.stop` on the `@click` on the event in the month view, which also seems to work.

I saw the unit test comment saying there is a problem testing click events with .self? Would writing a unit test testing .stop work?

## How to test this PR**. 

For example:  
1. Click event in month, check for propagation of date-was-clicked event
