### PR TITLE
an idea for prefering double clicks

### DIFF
--- a/development/cypress/EmittedEvents.vue
+++ b/development/cypress/EmittedEvents.vue
@@ -19,7 +19,7 @@ import {configInterface} from '../../src/typings/config.interface';
 import {WEEK_START_DAY} from "../../src/helpers/Time";
 
 export default defineComponent({
-  name: 'FiveDayWeek',
+  name: 'EmittedEvents',
 
   components: {Qalendar},
 
@@ -30,6 +30,7 @@ export default defineComponent({
         week: {
           startsOn: WEEK_START_DAY.SUNDAY,
         },
+        emitOnDoubleClick: true
       } as configInterface,
 
       events: [],

--- a/src/components/week/Day.vue
+++ b/src/components/week/Day.vue
@@ -1,7 +1,8 @@
 <template>
   <div
     class="calendar-week__day"
-    @click.self="handleClickOnDay"
+    @click.self="deligateClickOnDay"
+    @dblclick.native="deligateClickOnDay"
   >
     <DayEvent
       v-for="(event, eventIndex) in events"
@@ -154,6 +155,14 @@ export default defineComponent({
         dayStartTimeString,
         this.time.HOURS_PER_DAY,
       ).getIntervals()
+    },
+
+    deligateClickOnDay(event: MouseEvent) {
+      if (this.config?.emitOnDoubleClick === true) {
+        event.type === 'dblclick' && this.handleClickOnDay(event)
+      } else {
+        this.handleClickOnDay(event)
+      }
     },
 
     handleClickOnDay(event: MouseEvent) {

--- a/src/typings/config.interface.ts
+++ b/src/typings/config.interface.ts
@@ -84,4 +84,5 @@ export interface configInterface {
   // from an implementer is strongly discouraged
   // TODO: create internal config interface and replace all usages in components with that
   isSmall?: boolean;
+  emitOnDoubleClick?: boolean;
 }


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply::

- [ ] If committing a bugfix, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [ X ] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [ ] If committing a new feature, I have also written an appropriate test suite for it. 

I have tested the following:  

- [ ] Qalendar component in month mode. 
- [ ] Qalendar component in week mode. 
- [ ] Qalendar component in day mode. 
- [ ] All of the above modes on emulated mobile view. 
- [ ] Dragging and dropping events. 
- [ ] Resizing events in day/week modes. 
- [ ] Clicking events to open event dialog. 

## This PR solves the following problem**. 

Allows user to specify that they only want to listen for double click events, then only emits on double click events. I do see that you are deprecating the day-was-clicked event, but I wasn't seeing that it was implemented yet. 

## How to test this PR**. 

For example:  
Double click a day where the config option emitOnDoubleClick is set to true. Note that with this option set to true, single clicks are not emitted.

I can flesh out this PR more if you are interested in this idea.

https://github.com/tomosterlund/qalendar/issues/244
