### PR TITLE
Fixed package json by adding types in export

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "exports": {
     ".": {
       "import": "./dist/qalendar.es.js",
+      "types": "./dist/src/index.d.ts",
       "require": "./dist/qalendar.umd.js"
     },
     "./dist/style.css": {


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply::

- [ ] If committing a bugfix, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [ ] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [ ] If committing a new feature, I have also written an appropriate test suite for it. 
- [x] My pr is not a feature fix; it is a package fix

I have tested the following:  

**This does not apply**
- [ ] Qalendar component in month mode. 
- [ ] Qalendar component in week mode. 
- [ ] Qalendar component in day mode. 
- [ ] All of the above modes on emulated mobile view. 
- [ ] Dragging and dropping events. 
- [ ] Resizing events in day/week modes. 
- [ ] Clicking events to open event dialog. 

## This PR solves the following problem**. 
Newer releases of typescript are not able to detect types for this project since they were not included in the export field.

## How to test this PR**. 
1. Install the module
2. Import the component anywhere in a `<script setup lang="ts"/>` block.
3. It doesn’t show an error now