### PR TITLE
feat: Support Korean Language

### DIFF
--- a/src/language/index.ts
+++ b/src/language/index.ts
@@ -15,6 +15,7 @@ export const localeMap = new Map<string, string>([
   ['es', 'es-ES'],
   ['ja', 'ja-JP'],
   ['pl', 'pl-PL'],
+  ['ko', 'ko-KR'],
 ]);
 
 export default {

--- a/src/language/keys.ts
+++ b/src/language/keys.ts
@@ -14,7 +14,8 @@ export const languageKeys = {
     "ar-YE": "إسبوع",
     "es-ES": "Semana",
     "ja-JP": "週",
-    "pl-PL": "Tydzień", 
+    "pl-PL": "Tydzień",
+    "ko-KR": "주",
   },
   month: {
     "it-IT": "Mese",
@@ -30,7 +31,8 @@ export const languageKeys = {
     "ar-YE": "شهر",
     "es-ES": "Mes",
     "ja-JP": "月",
-    "pl-PL": "Miesiąc", 
+    "pl-PL": "Miesiąc",
+    "ko-KR": "월",
   },
   day: {
     "it-IT": "Giorno",
@@ -47,6 +49,7 @@ export const languageKeys = {
     "es-ES": "Día",
     "ja-JP": "日",
     "pl-PL": "Dzień",
+    "ko-KR": "일",
   },
 
   /** Other keys */
@@ -65,6 +68,7 @@ export const languageKeys = {
     "es-ES": "más eventos",
     "ja-JP": "その他イベント",
     "pl-PL": "+ więcej wydarzeń",
+    "ko-KR": "+ 더 보기",
   },
   noEvent: {
     'it-IT': 'Nessun evento',
@@ -81,5 +85,6 @@ export const languageKeys = {
     'es-ES': 'No hay eventos',
     "ja-JP": "イベントなし",
     "pl-PL": "Brak wydarzeń",
+    "ko-KR": "일정 없음",
   },
 };


### PR DESCRIPTION
## Checklist

Please put "X" in the below checkboxes that apply::

- [x] If committing a bugfix, I have tested it in different browsers (Chrome, Firefox, Safari). 
- [x] If committing a new feature, I have first submitted an issue (Please note: you are free to open PRs for non-issued features, but opening an issue increases your chance of a successful PR). 
- [x] If committing a new feature, I have also written an appropriate test suite for it. 

I have tested the following:  

- [x] Qalendar component in month mode. 
- [x] Qalendar component in week mode. 
- [x] Qalendar component in day mode. 
- [x] All of the above modes on emulated mobile view. 
- [x] Dragging and dropping events. 
- [x] Resizing events in day/week modes. 
- [x] Clicking events to open event dialog. 

## This PR solves the following problem**. 

Additional resource for Korean support.
No any changes, only resource. (Just got removed trail whitespace in  Polish resource)

## How to test this PR**. 

For example:  
1. Feed X and Y in the events-Prop. 
1. Click Z or A. 
2. Confirm that B is displayed. 
